### PR TITLE
add CustomResponse for Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+# Cargo or Rust
 target
 Cargo.lock
+
+# Editor Or IDE
+.idea/
+.vscode/

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,12 +2,19 @@ use hyper::status::StatusCode;
 use hyper::header::Headers;
 
 /// Sapper response struct
+#[derive(Debug, Clone)]
 pub struct SapperResponse {
     status: StatusCode,
     headers: Headers,
     body: Option<Vec<u8>>,
 }
 
+impl PartialEq for SapperResponse {
+    fn eq(&self, other: &Self) -> bool {
+        self.status() == other.status() && self.headers() == other.headers()
+            && self.body() == other.body()
+    }
+}
 
 impl SapperResponse {
     pub fn new() -> SapperResponse {


### PR DESCRIPTION
there something like

```rust
fn do_something() -> Option<Info> {
    // some code may return None
}

fn custom_response() -> Response {
    // some code build custom response
}
```
with this commit, you could write code like

```rust
fn with_custom_response_error(req: &mut Request, res: Response) -> SapperResult<Response> {
    let info = do_something().ok_or(SapperError::CustomResponse(custom_response()))?; // success or return custom response immediately
    // some code
    Ok(res)
}
```
without this commit, you have to write code like

```rust
fn without_custom_response_error(req: &mut Request, res: Response) -> SapperResult<Response> {
    if let Some(info) = do_something() {
        // some code
        Ok(res)
    } else {
        Ok(custom_response())
    }
}
```